### PR TITLE
Update homepage to use github URL

### DIFF
--- a/fluent-plugin-dynatrace.gemspec
+++ b/fluent-plugin-dynatrace.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Dynatrace Open Source Engineering']
   gem.email         = ['opensource@dynatrace.com']
   gem.summary       = 'A fluentd output plugin for sending logs to the Dynatrace Generic log ingest API v2'
-  gem.homepage      = 'https://www.dynatrace.com/'
+  gem.homepage      = 'https://github.com/dynatrace-oss/fluent-plugin-dynatrace'
   gem.licenses      = ['Apache-2.0']
 
   gem.metadata = {

--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.1.2'
+        '0.1.3'
       end
     end
   end


### PR DESCRIPTION
When the plugin is listed in https://www.fluentd.org/plugins/all the link URL comes from the gemspec homepage field. Users on that page are most likely looking for the gem itself, not Dynatrace.