### PR TITLE
lock concurrent thread access to outgoing connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Below is an example configuration which sends all logs with tags starting with `
 </match>
 ```
 
+If configured with custom `<buffer>` settings, it is recommended to set `flush_thread_count` to `1`.
+The output plugin is limited to a single outgoing connection to Dynatrace and multiple export threads will have limited impact on export latency.
+
 ### match directive
 
 - `required`

--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.1.3'
+        '0.1.4'
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -117,10 +117,10 @@ module Fluent
       end
 
       def send_to_dynatrace(body)
-        agent.start unless agent.started?
-
-        req = prepare_request(@uri)
         AGENT_LOCK.synchronize do
+          agent.start unless agent.started?
+
+          req = prepare_request(@uri)
           res = @agent.request(req, body)
 
           return if res.is_a?(Net::HTTPSuccess)

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -24,7 +24,7 @@ module Fluent
     class DynatraceOutput < Output
       Fluent::Plugin.register_output('dynatrace', self)
 
-      AGENT_LOCK = Mutex.new
+      HTTP_REQUEST_LOCK = Mutex.new
 
       helpers :compat_parameters # add :inject if need be
 
@@ -117,7 +117,7 @@ module Fluent
       end
 
       def send_to_dynatrace(body)
-        AGENT_LOCK.synchronize do
+        HTTP_REQUEST_LOCK.synchronize do
           agent.start unless agent.started?
 
           req = prepare_request(@uri)

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -120,13 +120,13 @@ module Fluent
         agent.start unless agent.started?
 
         req = prepare_request(@uri)
-        AGENT_LOCK.synchronize {
+        AGENT_LOCK.synchronize do
           res = @agent.request(req, body)
 
           return if res.is_a?(Net::HTTPSuccess)
 
           raise failure_message res
-        }
+        end
       end
 
       def failure_message(res)


### PR DESCRIPTION
Fixes a bug where running the plugin with a multi-thread buffer could crash due to concurrent access to non-thread-safe http connection.