### PR TITLE
Adapt example config in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ td-agent-gem install fluent-plugin-dynatrace
 
 ## Configuration options
 
-Below is an example configuration which sends all logs with tags starting with `dt.` to Dynatrace.
+Below is an example configuration which sends all logs with tags starting with `dt` to Dynatrace.
 
 ```
-<match dt.*>
+<match dt.**>
   @type              dynatrace
   active_gate_url    https://{your-environment-activegate}:8021/e/{your-tenant}/api/v2/logs/ingest
   api_token          api_token


### PR DESCRIPTION
`dt.*` will only match tags having exactly one component after `dt` while `dt.**` actually does what the description implies.
See https://docs.fluentd.org/configuration/config-file#how-do-the-match-patterns-work.