### PR TITLE
Fixed environment variable name on example

### DIFF
--- a/example/configmap-activegate.yaml
+++ b/example/configmap-activegate.yaml
@@ -90,7 +90,7 @@ data:
     # Send to dynatrace log ingest
     <match kubernetes.**>
       @type dynatrace
-      active_gate_url "#{ENV['AG_INGEST_URL']}"
+      active_gate_url "#{ENV['INGEST_ENDPOINT']}"
       api_token "#{ENV['LOG_INGEST_TOKEN']}"
       ssl_verify_none true
       <buffer>

--- a/example/configmap-saas.yaml
+++ b/example/configmap-saas.yaml
@@ -86,7 +86,7 @@ data:
     # Send to dynatrace log ingest
     <match kubernetes.**>
       @type dynatrace
-      active_gate_url "#{ENV['AG_INGEST_URL']}"
+      active_gate_url "#{ENV['INGEST_ENDPOINT']}"
       api_token "#{ENV['LOG_INGEST_TOKEN']}"
       ssl_verify_none true
       <buffer>

--- a/example/fluentd.yaml
+++ b/example/fluentd.yaml
@@ -40,7 +40,7 @@ spec:
             configMapKeyRef:
               name: fluentd-ingest-configuration
               key: CLUSTER_ID
-        - name: AG_INGEST_URL
+        - name: INGEST_ENDPOINT
           valueFrom:
             configMapKeyRef:
               name: fluentd-ingest-configuration

--- a/example/fluentd.yaml
+++ b/example/fluentd.yaml
@@ -40,7 +40,7 @@ spec:
             configMapKeyRef:
               name: fluentd-ingest-configuration
               key: CLUSTER_ID
-        - name: INGEST_ENDPOINT
+        - name: AG_INGEST_URL
           valueFrom:
             configMapKeyRef:
               name: fluentd-ingest-configuration


### PR DESCRIPTION
Fixed environment variable name ~(INGEST_ENDPOINT -> AG_INGEST_URL)~ AG_INGEST_URL -> INGEST_ENDPOINT 

**Update**: I did a new commit reverting the INGEST_ENDPOINT -> AG_INGEST_URL rename in fluentd daemonset then renamed AG_INGEST_URL to INGEST_ENDPOIN in configmap (both configmap-activegate.yaml and configmap-saas.yaml) to get the variable name same as confimap key to get code more readable.

**ps**: I believe this change is necessary in order to avoid other people to make the same mistake as I did when following example here (#29).