### PR TITLE
Add validation to active_gate_url and api_token

### DIFF
--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.1.6'
+        '0.2.0'
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -188,6 +188,8 @@ module Fluent
         raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless
           %w[http https].include?(uri.scheme)
 
+        raise Fluent::ConfigError, 'active_gate_url must include an authority' if uri.host.nil?
+
         uri
       end
     end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -64,9 +64,9 @@ module Fluent
         compat_parameters_convert(conf, :inject)
         super
 
-        raise Fluent::ConfigError, 'api_token has not been set' if @api_token.empty?
+        raise Fluent::ConfigError, 'api_token is empty' if @api_token.empty?
 
-        @uri = parse_uri(@active_gate_url)
+        @uri = parse_and_validate_uri(@active_gate_url)
 
         @agent = Net::HTTP.new(@uri.host, @uri.port)
 
@@ -181,8 +181,8 @@ module Fluent
 
       private
 
-      def parse_uri(uri_string)
-        raise Fluent::ConfigError, 'active_gate_url has not been set' if uri_string.empty?
+      def parse_and_validate_uri(uri_string)
+        raise Fluent::ConfigError, 'active_gate_url is empty' if uri_string.empty?
 
         uri = URI.parse(uri_string)
         raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -64,10 +64,9 @@ module Fluent
         compat_parameters_convert(conf, :inject)
         super
 
-        raise Fluent::ConfigError, 'active_gate_url has not been set' if @active_gate_url.empty?
         raise Fluent::ConfigError, 'api_token has not been set' if @api_token.empty?
 
-        @uri = URI.parse(@active_gate_url)
+        @uri = parse_uri(@active_gate_url)
         raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless
           %w[http https].include?(@uri.scheme)
 
@@ -178,6 +177,15 @@ module Fluent
                       end
 
         "failed to request #{uri} (#{res_summary})"
+      end
+
+      #############################################
+
+      private
+
+      def parse_uri(uri_string)
+        raise Fluent::ConfigError, 'active_gate_url has not been set' if uri_string.empty?
+        @uri = URI.parse(@active_gate_url)
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -64,7 +64,11 @@ module Fluent
         compat_parameters_convert(conf, :inject)
         super
 
+        raise Fluent::ConfigError, "active_gate_url has not been set" if @active_gate_url == ''
+
         @uri = URI.parse(@active_gate_url)
+        raise Fluent::ConfigError, "active_gate_url scheme must be http or https" unless %w[http https].include?(@uri.scheme)
+
         @agent = Net::HTTP.new(@uri.host, @uri.port)
 
         return unless uri.scheme == 'https'

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -64,7 +64,8 @@ module Fluent
         compat_parameters_convert(conf, :inject)
         super
 
-        raise Fluent::ConfigError, 'active_gate_url has not been set' if @active_gate_url == ''
+        raise Fluent::ConfigError, 'active_gate_url has not been set' if @active_gate_url.empty?
+        raise Fluent::ConfigError, 'api_token has not been set' if @api_token.empty?
 
         @uri = URI.parse(@active_gate_url)
         raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -67,8 +67,6 @@ module Fluent
         raise Fluent::ConfigError, 'api_token has not been set' if @api_token.empty?
 
         @uri = parse_uri(@active_gate_url)
-        raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless
-          %w[http https].include?(@uri.scheme)
 
         @agent = Net::HTTP.new(@uri.host, @uri.port)
 
@@ -185,7 +183,12 @@ module Fluent
 
       def parse_uri(uri_string)
         raise Fluent::ConfigError, 'active_gate_url has not been set' if uri_string.empty?
-        @uri = URI.parse(@active_gate_url)
+
+        uri = URI.parse(uri_string)
+        raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless
+          %w[http https].include?(uri.scheme)
+
+        uri
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -64,10 +64,11 @@ module Fluent
         compat_parameters_convert(conf, :inject)
         super
 
-        raise Fluent::ConfigError, "active_gate_url has not been set" if @active_gate_url == ''
+        raise Fluent::ConfigError, 'active_gate_url has not been set' if @active_gate_url == ''
 
         @uri = URI.parse(@active_gate_url)
-        raise Fluent::ConfigError, "active_gate_url scheme must be http or https" unless %w[http https].include?(@uri.scheme)
+        raise Fluent::ConfigError, 'active_gate_url scheme must be http or https' unless
+          %w[http https].include?(@uri.scheme)
 
         @agent = Net::HTTP.new(@uri.host, @uri.port)
 

--- a/test/plugin/out_dynatrace_test.rb
+++ b/test/plugin/out_dynatrace_test.rb
@@ -145,6 +145,45 @@ class MyOutputTest < Test::Unit::TestCase
       assert_equal true, d.instance.agent.original_agent.use_ssl?
       assert_equal OpenSSL::SSL::VERIFY_NONE, d.instance.agent.original_agent.verify_mode
     end
+
+    test 'should throw if active_gate_url is not set' do
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url
+        api_token       secret
+      ))
+      end
+    end
+
+    test 'should throw if active_gate_url scheme is not http or https' do
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url ./relative/path
+        api_token       secret
+      ))
+      end
+
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url example.dynatrace.com/logs
+        api_token       secret
+      ))
+      end
+
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url example
+        api_token       secret
+      ))
+      end
+
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url ssh://example.dynatrace.com/logs
+        api_token       secret
+      ))
+      end
+    end
   end
 
   sub_test_case 'tests for #write' do

--- a/test/plugin/out_dynatrace_test.rb
+++ b/test/plugin/out_dynatrace_test.rb
@@ -192,6 +192,13 @@ class MyOutputTest < Test::Unit::TestCase
         api_token       secret
       ))
       end
+
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url http:path/to/logs
+        api_token       secret
+      ))
+      end
     end
 
     test 'should throw if api_token is not set' do

--- a/test/plugin/out_dynatrace_test.rb
+++ b/test/plugin/out_dynatrace_test.rb
@@ -160,7 +160,7 @@ class MyOutputTest < Test::Unit::TestCase
         active_gate_url http://[::1]//logs
         api_token       secret
       ))
-      assert_equal "http://[::1]//logs", d.instance.active_gate_url
+      assert_equal 'http://[::1]//logs', d.instance.active_gate_url
       assert_equal 'secret', d.instance.api_token
     end
 

--- a/test/plugin/out_dynatrace_test.rb
+++ b/test/plugin/out_dynatrace_test.rb
@@ -155,6 +155,15 @@ class MyOutputTest < Test::Unit::TestCase
       end
     end
 
+    test 'with IPv6 as host should not throw' do
+      d = create_driver(%(
+        active_gate_url http://[::1]//logs
+        api_token       secret
+      ))
+      assert_equal "http://[::1]//logs", d.instance.active_gate_url
+      assert_equal 'secret', d.instance.api_token
+    end
+
     test 'should throw if active_gate_url scheme is not http or https' do
       assert_raises Fluent::ConfigError do
         create_driver(%(
@@ -181,6 +190,15 @@ class MyOutputTest < Test::Unit::TestCase
         create_driver(%(
         active_gate_url ssh://example.dynatrace.com/logs
         api_token       secret
+      ))
+      end
+    end
+
+    test 'should throw if api_token is not set' do
+      assert_raises Fluent::ConfigError do
+        create_driver(%(
+        active_gate_url https://example.dynatrace.com/logs
+        api_token
       ))
       end
     end


### PR DESCRIPTION
This PR adds validation to the `active_gate_url` configuration property, raising a `Fluent::ConfigError` when

- `active_gate_url` is an empty string
- `active_gate_url` does not contain the scheme `http` or `https`
- `api_token` is an empty string

Resovles #32 