### PR TITLE
Add multi-env configuration

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -25,13 +25,11 @@ This is either an ActiveGate, which might already exist in your environment or a
 ### Option 1: Deploy an ActiveGate
 
 1. Create a secret holding the environment URL and login credentials for this registry, making sure to replace
-
    - `${YOUR_ENVIRONMENT_URL}` with your Dynatrace environment URL without 'https' (e.g., `env123456.live.dynatrace.com`)
    - `${YOUR_ENVIRONMENT_ID}` with the ID of your Dynatrace environment (e.g., `env123456`)
    - `${YOUR_PAAS_TOKEN}` with the PaaS token you created as described in the Prerequisites
 
    ``kubectl create secret docker-registry tenant-docker-registry --docker-server=${YOUR_ENVIRONMENT_URL} --docker-username=${YOUR_ENVIRONMENT_ID} --docker-password=${YOUR_PAAS_TOKEN} -n dynatrace``
-
 2. Edit the file named `configmap-activegate.yaml`, making sure to replace
    - `${YOUR_ENVIRONMENT_ID}` with the ID of your Dynatrace environment (e.g., `env123456`)
    - `${YOUR_CLUSTER_ID}` with your Kubernetes Cluster ID which can be retrieved using this command:
@@ -39,12 +37,9 @@ This is either an ActiveGate, which might already exist in your environment or a
      ``kubectl get namespace kube-system  -o jsonpath='{.metadata.uid}'``
 
    - your `fluent.conf` file with a configuration suiting your environment. Our example is using the kubernetes-metadata-filter to enrich ingested log lines with information about its underlying kubernetes infrastructure. **Depending on the applications on your cluster you might need to manually modify the `fluent.conf` file.**
-
 3. Edit the file named `activegate.yaml`, making sure to replace
    - `${YOUR_ENVIRONMENT_URL}` with your Dynatrace environment URL (without 'https' (e.g., `env123456.live.dynatrace.com`)
-
 4. That same `activegate.yaml` also deploys a persistent volume to queue log entries that were not pushed to Dynatrace yet. Make sure you have a persistent volume or storage class readily available.
-
 5. Deploy Configmap and ActiveGate
 
    ``kubectl apply -f activegate.yaml configmap-activegate.yaml``
@@ -60,9 +55,7 @@ Not only your ActiveGate presents an endpoint, but also your Dynatrace environme
      ``kubectl get namespace kube-system  -o jsonpath='{.metadata.uid}'``
 
    - your `fluent.conf` file with a configuration suiting your environment. Our example is using the kubernetes-metadata-filter to enrich ingested log lines with information about its underlying kubernetes infrastructure. **Depending on the applications on your cluster you might need to manually modify the `fluent.conf` file.**
-
 2. Deploy Configmap and ActiveGate
-
    ``kubectl apply -f configmap-saas.yaml``
 
 ## Build FluentD docker image
@@ -76,21 +69,17 @@ Build the FluentD docker image provided in our example and upload it to your rep
    ``kubectl create secret generic tokens --from-literal="log-ingest=${YOUR_API_TOKEN}" -n dynatrace``
 
 2. Replace `${YOUR_FLUENTD_IMAGE}` in `fluentd.yaml` with the fluentd image you built
-
 3. Deploy `fluentd.yaml`
 
    ``kubectl apply -f fluentd.yaml``
 
 ## Sending logs to different Dynatrace environments
 
-With the introduction of Cloud Native Full Stack injection [example](https://github.com/Dynatrace/dynatrace-operator/blob/master/config/samples/cloudNativeFullStack.yaml) it is possible to send metrics and traces to more than one Dynatrace environment. The same thing can be done for logs using fluentd. The following example serves as a potential reference implementation. Results may vary.
+With the introduction of [Cloud Native Full Stack injection](https://github.com/Dynatrace/dynatrace-operator/blob/master/config/samples/cloudNativeFullStack.yaml), a feature of our [Dynatrace Operator](https://github.com/Dynatrace/dynatrace-operator/), it is possible to send metrics and traces to more than one Dynatrace environment. The same thing can be done for logs using fluentd. The following example serves as a potential reference implementation. Results may vary.
 
 Adapt the "option 2" instructions above as follows:
 
-1. Create a second API token, from a second Dynatrace environment. Create a second kubernetes for it as well (ex: `log-ingest2`)
-
+1. Create a second API token, from a second Dynatrace environment. Create a second kubernetes secret for it as well (ex: `log-ingest2`)
 2. Adapt the fluentd config map to include a second API endpoints, and a filter for targeted namespaces as shown in [configmap-multi.yaml](configmap-multi.yaml).
-
-3. Adapt the fluentd.yaml file to reference both API endpoints (`INGEST_ENDPOINT1 and INGEST_ENDPOINT2`) as shown in [fluentd-multi.yaml](fluentd-multi.yaml).
-
+3. Adapt the fluentd.yaml file to reference both API endpoints (`INGEST_ENDPOINT_1 and INGEST_ENDPOINT_2`) as shown in [fluentd-multi.yaml](fluentd-multi.yaml).
 4. Further adapt the same fluentd.yaml to reference both of the secrets you created also show in [fluentd-multi.yaml](fluentd-multi.yaml).

--- a/example/README.md
+++ b/example/README.md
@@ -80,3 +80,17 @@ Build the FluentD docker image provided in our example and upload it to your rep
 3. Deploy `fluentd.yaml`
 
    ``kubectl apply -f fluentd.yaml``
+
+## Sending logs to different Dynatrace environments
+
+With the introduction of Cloud Native Full Stack injection [example](https://github.com/Dynatrace/dynatrace-operator/blob/master/config/samples/cloudNativeFullStack.yaml) it is possible to send metrics and traces to more than one Dynatrace environment. The same thing can be done for logs using fluentd. The following example serves as a potential reference implementation. Results may vary.
+
+Adapt the "option 2" instructions above as follows:
+
+1. Create a second API token, from a second Dynatrace environment. Create a second kubernetes for it as well (ex: `log-ingest2`)
+
+2. Adapt the fluentd config map to include a second API endpoints, and a filter for targeted namespaces as shown in [configmap-multi.yaml](configmap-multi.yaml).
+
+3. Adapt the fluentd.yaml file to reference both API endpoints (`INGEST_ENDPOINT1 and INGEST_ENDPOINT2`) as shown in [fluentd-multi.yaml](fluentd-multi.yaml).
+
+4. Further adapt the same fluentd.yaml to reference both of the secrets you created also show in [fluentd-multi.yaml](fluentd-multi.yaml).

--- a/example/configmap-multi.yaml
+++ b/example/configmap-multi.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: dynatrace
 data:
   CLUSTER_ID: "${YOUR_CLUSTER_ID}"
-  INGEST_ENDPOINT1: "https://${YOUR_ENVIRONMENT_ID1}.live.dynatrace.com/api/v2/logs/ingest"
-  INGEST_ENDPOINT2: "https://${YOUR_ENVIRONMENT_ID2}.live.dynatrace.com/api/v2/logs/ingest"
+  INGEST_ENDPOINT_1: "https://${YOUR_ENVIRONMENT_ID_1}.live.dynatrace.com/api/v2/logs/ingest"
+  INGEST_ENDPOINT_2: "https://${YOUR_ENVIRONMENT_ID_2}.live.dynatrace.com/api/v2/logs/ingest"
   fluent.conf: |
     # Ingest logs from nodes
     <source>
@@ -89,8 +89,8 @@ data:
 
     <match namespace1.kubernetes.**>
       @type dynatrace
-      active_gate_url "#{ENV['INGEST_ENDPOINT1']}"
-      api_token "#{ENV['LOG_INGEST_TOKEN1']}"
+      active_gate_url "#{ENV['INGEST_ENDPOINT_1']}"
+      api_token "#{ENV['LOG_INGEST_TOKEN_1']}"
       ssl_verify_none true
       <buffer>
         retry_max_times 3
@@ -99,8 +99,8 @@ data:
 
     <match namespace2.kubernetes.**>
       @type dynatrace
-      active_gate_url "#{ENV['INGEST_ENDPOINT2']}"
-      api_token "#{ENV['LOG_INGEST_TOKEN2']}"
+      active_gate_url "#{ENV['INGEST_ENDPOINT_2']}"
+      api_token "#{ENV['LOG_INGEST_TOKEN_2']}"
       ssl_verify_none true
       <buffer>
         retry_max_times 3

--- a/example/configmap-multi.yaml
+++ b/example/configmap-multi.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-ingest-configuration
+  namespace: dynatrace
+data:
+  CLUSTER_ID: "${YOUR_CLUSTER_ID}"
+  INGEST_ENDPOINT1: "https://${YOUR_ENVIRONMENT_ID1}.live.dynatrace.com/api/v2/logs/ingest"
+  INGEST_ENDPOINT2: "https://${YOUR_ENVIRONMENT_ID2}.live.dynatrace.com/api/v2/logs/ingest"
+  fluent.conf: |
+    # Ingest logs from nodes
+    <source>
+      @id in_tail_container_logs
+      @type tail
+      tag raw.kubernetes.*
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd.pos
+      read_from_head true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format regexp
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+          expression /^(?<time>.+)\b(?<stream>stdout|stderr)\b(?<log>.*)$/
+        </pattern>
+      </parse>
+    </source>
+
+    # Detect exceptions in the log output and forward them as one log entry.
+    <match raw.kubernetes.**>
+      @id raw.kubernetes
+      @type detect_exceptions
+      remove_tag_prefix raw
+      message log
+      stream stream
+      multiline_flush_interval 5
+      max_bytes 500000
+      max_lines 1000
+    </match>
+
+    # Concatenate multi-line logs
+    <filter **>
+      @id filter_concat
+      @type concat
+      key message
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+
+    # Enrich with kubernetes metadata
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    # Transform metadata to records
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+        <record>
+          status ${ record.dig(:log, :severity) || record.dig(:log, :level) || (record["log"] =~ /\W?\berror\b\W?/i ? "ERROR" : (record["log"] =~ /\W?\bwarn\b\W?/i ? "WARN" : (record["log"] =~ /\W?\bdebug\b\W?/i ? "DEBUG" : (record["log"] =~ /\W?\binfo\b\W?/i ? "INFO" : "NONE")))) }
+          content ${record["log"]}
+          container.name ${record.dig("kubernetes","container_name")}
+          container.image.name ${record.dig("kubernetes","container_image").split(':')[0]}
+          container.image.tag ${record.dig("kubernetes","container_image").split(':')[1]}
+          dt.kubernetes.node.name ${record.dig("kubernetes","host")}
+          dt.kubernetes.cluster.id "#{ENV['CLUSTER_ID']}"
+          dt.kubernetes.node.system_uuid ${File.read("/sys/devices/virtual/dmi/id/product_uuid").strip}
+          k8s.pod.labels ${record.dig("kubernetes","labels")}
+          k8s.namespace.uid ${record.dig("kubernetes","namespace_id")}
+          k8s.namespace.name ${record.dig("kubernetes","namespace_name")}
+          k8s.pod.name ${record.dig("kubernetes","pod_name")}
+          k8s.pod.uid ${record.dig("kubernetes","pod_id")}
+        </record>
+        remove_keys log, stream, docker, kubernetes
+    </filter>
+
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      <rule>
+        key k8s.namespace.name
+        pattern ^(.+)$
+        tag $1.${tag}
+      </rule>
+    </match>
+
+    <match namespace1.kubernetes.**>
+      @type dynatrace
+      active_gate_url "#{ENV['INGEST_ENDPOINT1']}"
+      api_token "#{ENV['LOG_INGEST_TOKEN1']}"
+      ssl_verify_none true
+      <buffer>
+        retry_max_times 3
+      </buffer>
+    </match>
+
+    <match namespace2.kubernetes.**>
+      @type dynatrace
+      active_gate_url "#{ENV['INGEST_ENDPOINT2']}"
+      api_token "#{ENV['LOG_INGEST_TOKEN2']}"
+      ssl_verify_none true
+      <buffer>
+        retry_max_times 3
+      </buffer>
+    </match>
+
+    <system>
+        log_level info
+    </system>

--- a/example/fluentd-multi.yaml
+++ b/example/fluentd-multi.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: dynatrace
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccountName: dynatrace-monitoring
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      initContainers:
+      - name: fluentd-permission-fix
+        image: busybox
+        command: ["sh","-c","touch /var/log/fluentd.pos; chmod -R 770 /var/log/fluentd.pos; "]
+        volumeMounts:
+        - name: var-log
+          mountPath: /var/log/
+      containers:
+      - name: fluentd
+        image: ${YOUR_FLUENTD_IMAGE}
+        imagePullPolicy: Always
+        env:
+        - name: FLUENT_UID
+          value: "0"
+        - name: CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              name: fluentd-ingest-configuration
+              key: CLUSTER_ID
+        - name: INGEST_ENDPOINT1
+          valueFrom:
+            configMapKeyRef:
+              name: fluentd-ingest-configuration
+              key: INGEST_ENDPOINT1
+        - name: INGEST_ENDPOINT2
+          valueFrom:
+            configMapKeyRef:
+              name: fluentd-ingest-configuration
+              key: INGEST_ENDPOINT2
+        - name: LOG_INGEST_TOKEN1
+          valueFrom:
+            secretKeyRef:
+              name: tokens
+              key: log-ingest
+        - name: LOG_INGEST_TOKEN2
+          valueFrom:
+            secretKeyRef:
+              name: tokens2
+              key: log-ingest
+        resources:
+          limits:
+            cpu: 200m
+            memory: 400Mi
+            ephemeral-storage: 1Gi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+            ephemeral-storage: 1Gi
+        volumeMounts:
+        - name: var-log
+          mountPath: /var/log/
+          readOnly: true
+        - name: var-lib
+          mountPath: /var/lib
+          readOnly: true
+        - name: var-log-pos
+          mountPath: /var/log/fluentd.pos
+        - name: fluentd-ingest-configuration
+          mountPath: /fluentd/etc/fluent.conf
+          subPath: fluent.conf
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: var-log
+        hostPath:
+          path: /var/log/
+      - name: var-lib
+        hostPath:
+          path: /var/lib
+      - name: var-log-pos
+        hostPath:
+          path: /var/log/fluentd.pos
+          type: FileOrCreate
+      - name: fluentd-ingest-configuration
+        configMap:
+          name: fluentd-ingest-configuration
+          items:
+          - key: fluent.conf
+            path: fluent.conf

--- a/example/fluentd-multi.yaml
+++ b/example/fluentd-multi.yaml
@@ -40,26 +40,26 @@ spec:
             configMapKeyRef:
               name: fluentd-ingest-configuration
               key: CLUSTER_ID
-        - name: INGEST_ENDPOINT1
+        - name: INGEST_ENDPOINT_1
           valueFrom:
             configMapKeyRef:
               name: fluentd-ingest-configuration
-              key: INGEST_ENDPOINT1
-        - name: INGEST_ENDPOINT2
+              key: INGEST_ENDPOINT_1
+        - name: INGEST_ENDPOINT_2
           valueFrom:
             configMapKeyRef:
               name: fluentd-ingest-configuration
-              key: INGEST_ENDPOINT2
-        - name: LOG_INGEST_TOKEN1
+              key: INGEST_ENDPOINT_2
+        - name: LOG_INGEST_TOKEN_1
           valueFrom:
             secretKeyRef:
               name: tokens
               key: log-ingest
-        - name: LOG_INGEST_TOKEN2
+        - name: LOG_INGEST_TOKEN_2
           valueFrom:
             secretKeyRef:
-              name: tokens2
-              key: log-ingest
+              name: tokens
+              key: log-ingest2
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
This is an additional example for customers who want to route the logs of certain namespaces to different dynatrace log endpoints.

Replaces #35.