### PR TITLE
Update user agent version format

### DIFF
--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.2.0'
+        '0.2.1'
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -122,7 +122,7 @@ module Fluent
       #############################################
 
       def user_agent
-        "fluent-plugin-dynatrace v#{DynatraceOutputConstants.version}"
+        "fluent-plugin-dynatrace/#{DynatraceOutputConstants.version}"
       end
 
       def prepare_request

--- a/test/integration_dtcluster/plugin_dt_test.rb
+++ b/test/integration_dtcluster/plugin_dt_test.rb
@@ -85,7 +85,7 @@ class TestPluginDynatraceIntegration < Test::Unit::TestCase
     agent.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
     options = {
-      'User-Agent' => "fluent-plugin-dynatrace-tests v#{Fluent::Plugin::DynatraceOutputConstants.version}"
+      'User-Agent' => "fluent-plugin-dynatrace-tests/#{Fluent::Plugin::DynatraceOutputConstants.version}"
     }
     req = Net::HTTP::Get.new(uri, options)
     req['Authorization'] = "Api-Token #{api_token}"

--- a/test/integration_fluent/fixtures/logsink/server.js
+++ b/test/integration_fluent/fixtures/logsink/server.js
@@ -30,7 +30,7 @@ const server = http.createServer((req, res) => {
       process.stdout.write("Missing user agent header");
     }
 
-    if (!ua.match(/^fluent-plugin-dynatrace v\d+\.\d+\.\d+$/)) {
+    if (!ua.match(/^fluent-plugin-dynatrace\/\d+\.\d+\.\d+$/)) {
       process.stdout.write("Invalid user agent header");
     }
 

--- a/test/plugin/out_dynatrace_test.rb
+++ b/test/plugin/out_dynatrace_test.rb
@@ -224,7 +224,7 @@ class MyOutputTest < Test::Unit::TestCase
 
       content = d.instance.agent.result.data[0]
 
-      assert_equal "fluent-plugin-dynatrace v#{Fluent::Plugin::DynatraceOutputConstants.version}",
+      assert_equal "fluent-plugin-dynatrace/#{Fluent::Plugin::DynatraceOutputConstants.version}",
                    d.instance.agent.result.headers['user-agent']
       assert_equal content['message'], 'this is a test message'
       assert_equal content['amount'], 53


### PR DESCRIPTION
Update user agent version format to follow [RFC 7231, 5.5.3](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3).