### PR TITLE
Add note on OpenShift to k8s example and mention support level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fluent-plugin-dynatrace, a plugin for [fluentd](https://www.fluentd.org/)
 
-> This project is developed and maintained by Dynatrace R&D.
+> This project is developed, maintained and supported by Dynatrace.
 
 A fluentd output plugin for sending logs to the Dynatrace [Generic log ingest API v2](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/log-monitoring-v2/post-log-ingest/).
 

--- a/example/README.md
+++ b/example/README.md
@@ -72,6 +72,10 @@ Build the FluentD docker image provided in our example and upload it to your rep
 3. Deploy `fluentd.yaml`
 
    ``kubectl apply -f fluentd.yaml``
+   
+> **Note**: When running this example on **OpenShift**, you'll need to run the fluentd container as a privileged container,
+as the daemonset setting mounts `/var/log` using the service account `fluentd`. See [https://github.com/fluent/fluentd-kubernetes-daemonset#running-on-openshift](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/ce4b80e0a1ac2b077bbcf4b1c3a243ac5dae1aa2/README.md#running-on-openshift)
+for an example.
 
 ## Sending logs to different Dynatrace environments
 

--- a/example/README.md
+++ b/example/README.md
@@ -73,9 +73,9 @@ Build the FluentD docker image provided in our example and upload it to your rep
 
    ``kubectl apply -f fluentd.yaml``
    
-> **Note**: When running this example on **OpenShift**, you'll need to run the fluentd container as a privileged container,
-as the daemonset setting mounts `/var/log` using the service account `fluentd`. See [https://github.com/fluent/fluentd-kubernetes-daemonset#running-on-openshift](https://github.com/fluent/fluentd-kubernetes-daemonset/blob/ce4b80e0a1ac2b077bbcf4b1c3a243ac5dae1aa2/README.md#running-on-openshift)
-for an example.
+> **Note**: When running this example on **OpenShift**, you'll need to run the fluentd container as a privileged container.
+This is because the daemonset setting mounts `/var/log` using the service account `fluentd`.
+See [https://github.com/fluent/fluentd-kubernetes-daemonset#running-on-openshift] https://github.com/fluent/fluentd-kubernetes-daemonset/blob/ce4b80e0a1ac2b077bbcf4b1c3a243ac5dae1aa2/README.md#running-on-openshift) for an example.
 
 ## Sending logs to different Dynatrace environments
 


### PR DESCRIPTION
There are some things to consider when deploying fluentd on OpenShift, so I added a link to the respective fluentd docs for that to our k8s example. I also mentioned the support level as requested in #39.