### PR TITLE
Fix CI: update tested Ruby versions, remove deprecated set-output

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # 3.0 in quotes for https://github.com/actions/runner/issues/849
-  SUPPORTED_VERSIONS: '["3.0", 2.7, 2.6, 2.5]'
+  SUPPORTED_VERSIONS: [ 2.7, '3.0', 3.1, 3.2]
 
 jobs:
   supported-versions:
@@ -18,7 +18,7 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        echo "::set-output name=matrix::${{env.SUPPORTED_VERSIONS}}"
+        echo "matrix=${{env.SUPPORTED_VERSIONS}}" >> $GITHUB_OUTPUT
   unit-test:
     needs: supported-versions
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # 3.0 in quotes for https://github.com/actions/runner/issues/849
-  SUPPORTED_VERSIONS: [ 2.7, '3.0', 3.1, 3.2]
+  SUPPORTED_VERSIONS: "[ 2.7, '3.0', 3.1, 3.2]"
 
 jobs:
   supported-versions:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec
 
+Gemspec/RequireMFA:
+  Severity: info
+
 Naming/MethodParameterName:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   NewCops: enable
 
 Naming/MethodParameterName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
 
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Naming/MethodParameterName:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A fluentd output plugin for sending logs to the Dynatrace [Generic log ingest AP
 ## Requirements
 
 - An instance of fluentd >= v1.0 from which logs should be exported
-- Ruby version >= 2.4.0
+- Ruby version >= 2.7.0
 - An ActiveGate with the Generic log ingest API v2 enabled as described in the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/log-monitoring-log-data-ingestion)
 - A [Dynatrace API token](https://www.dynatrace.com/support/help/shortlink/api-authentication) with the `logs.ingest` (Ingest Logs) scope
 
@@ -88,7 +88,7 @@ An full example demonstrating how to set up Fluentd on Kubernetes and export log
 
 ## Development
 
-`fluent-plugin-dynatrace` supports Ruby versions `>= 2.4.0` but it is recommended that at least `2.7.2` is used for development. Ruby versions can be managed with tools like [chruby](https://github.com/postmodern/chruby) or [rbenv](https://github.com/rbenv/rbenv).
+`fluent-plugin-dynatrace` supports Ruby versions `>= 2.7.0` but it is recommended that at least `2.7.2` is used for development. Ruby versions can be managed with tools like [chruby](https://github.com/postmodern/chruby) or [rbenv](https://github.com/rbenv/rbenv).
 
 ### Install Dependencies
 

--- a/fluent-plugin-dynatrace.gemspec
+++ b/fluent-plugin-dynatrace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = '>= 2.4.0'
+  gem.required_ruby_version = '>= 2.7.0'
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.22', '< 2']
   gem.add_development_dependency 'bundler', ['>= 2', '<3']

--- a/fluent-plugin-dynatrace.gemspec
+++ b/fluent-plugin-dynatrace.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.22', '< 2']
   gem.add_development_dependency 'bundler', ['>= 2', '<3']
-  gem.add_development_dependency 'rake', '13.0.3'
-  gem.add_development_dependency 'rubocop', '1.9.1'
-  gem.add_development_dependency 'rubocop-rake', '0.5.1'
+  gem.add_development_dependency 'rake', '>= 13.1.0', '< 13.2.0'
+  gem.add_development_dependency 'rubocop', '1.59.0'
+  gem.add_development_dependency 'rubocop-rake', '0.6.0'
+  gem.add_development_dependency 'test-unit', '>= 3.6', '< 3.7.0'
 end

--- a/fluent-plugin-dynatrace.gemspec
+++ b/fluent-plugin-dynatrace.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.22', '< 2']
   gem.add_development_dependency 'bundler', ['>= 2', '<3']
-  gem.add_development_dependency 'rake', '>= 13.1.0', '< 13.2.0'
+  gem.add_development_dependency 'rake', '13.1.0'
   gem.add_development_dependency 'rubocop', '1.59.0'
   gem.add_development_dependency 'rubocop-rake', '0.6.0'
-  gem.add_development_dependency 'test-unit', '>= 3.6', '< 3.7.0'
+  gem.add_development_dependency 'test-unit', '3.6.1'
 end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -31,8 +31,8 @@ module Fluent
       # Configurations
       desc 'The full URL of the Dynatrace log ingestion endpoint, e.g. https://my-active-gate.example.com/api/logs/ingest'
       config_param :active_gate_url, :string
-      desc 'The API token to use to authenticate requests to the log ingestion endpoint. '\
-           'Must have logs.ingest (Ingest Logs) scope. '\
+      desc 'The API token to use to authenticate requests to the log ingestion endpoint. ' \
+           'Must have logs.ingest (Ingest Logs) scope. ' \
            'It is recommended to limit scope to only this one.'
       config_param :api_token, :string, secret: true
 

--- a/test/integration_dtcluster/plugin_dt_test.rb
+++ b/test/integration_dtcluster/plugin_dt_test.rb
@@ -28,7 +28,7 @@ class TestPluginDynatraceIntegration < Test::Unit::TestCase
 
   def active_gate_url
     # Expect an active gate url in the format https://127.0.0.1:9999/e/abc12345
-    url = ENV['ACTIVE_GATE_URL']
+    url = ENV.fetch('ACTIVE_GATE_URL', nil)
     raise 'expected environment variable ACTIVE_GATE_URL' if url.nil?
 
     url
@@ -36,7 +36,7 @@ class TestPluginDynatraceIntegration < Test::Unit::TestCase
 
   def api_token
     # Expect an API token with `logs.ingest` (Ingest Logs) and `logs.read` (Read Logs) scope
-    token = ENV['API_TOKEN']
+    token = ENV.fetch('API_TOKEN', nil)
     raise 'expected environment variable API_TOKEN' if token.nil?
 
     token

--- a/test/integration_dtcluster/plugin_dt_test.rb
+++ b/test/integration_dtcluster/plugin_dt_test.rb
@@ -97,7 +97,7 @@ class TestPluginDynatraceIntegration < Test::Unit::TestCase
     body = JSON.parse(res.body)
     results = body['results']
 
-    return false if results.length.zero?
+    return false if results.empty?
 
     assert_equal(results[0]['content'], nonce)
     true


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more info on set-output