### PR TITLE
Use Yajl as the json parser, in order to accept malformed json messages

### DIFF
--- a/fluent-plugin-dynatrace.gemspec
+++ b/fluent-plugin-dynatrace.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7.0'
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.22', '< 2']
+  gem.add_runtime_dependency 'yajl-ruby', ['~> 1.4', '>= 1.4.3']
   gem.add_development_dependency 'bundler', ['>= 2', '<3']
   gem.add_development_dependency 'rake', '13.1.0'
   gem.add_development_dependency 'rubocop', '1.59.0'

--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.2.1'
+        '0.2.2'
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -16,6 +16,7 @@
 
 require 'fluent/plugin/output'
 require 'net/http'
+require 'yajl'
 require_relative 'dynatrace_constants'
 
 module Fluent
@@ -155,7 +156,7 @@ module Fluent
 
       def serialize(records)
         log.on_trace { log.trace('#serialize') }
-        body = "#{records.to_json.chomp}\n"
+        body = "#{Yajl.dump(records)}\n"
         log.on_trace { log.trace("#serialize body length #{body.length}") }
         body
       end


### PR DESCRIPTION
This PR is proposed to fix the issue https://github.com/dynatrace-oss/fluent-plugin-dynatrace/issues/45.

The issue contains the full context of:
- what is the issue
- how it was identified
- why we need to fix it
- why using Yajl is the proposed fix