### PR TITLE
Remove default chunk size limit override

### DIFF
--- a/lib/fluent/plugin/dynatrace_constants.rb
+++ b/lib/fluent/plugin/dynatrace_constants.rb
@@ -20,7 +20,7 @@ module Fluent
     class DynatraceOutputConstants
       # The version of the Dynatrace output plugin
       def self.version
-        '0.2.1'
+        '0.3.0'
       end
     end
   end

--- a/lib/fluent/plugin/out_dynatrace.rb
+++ b/lib/fluent/plugin/out_dynatrace.rb
@@ -46,7 +46,6 @@ module Fluent
 
       config_section :buffer do
         config_set_default :flush_at_shutdown, true
-        config_set_default :chunk_limit_size, 10 * 1024
       end
 
       # Default injection parameters.


### PR DESCRIPTION
Removes the chunk size limit override we were previously applying. Fluent already has good default values and tuning for specific cases and performance is well covered in their docs.