### PR TITLE
Use safe navigation operator for container image name and tag

### DIFF
--- a/example/configmap-saas.yaml
+++ b/example/configmap-saas.yaml
@@ -69,8 +69,8 @@ data:
           status ${ record.dig(:log, :severity) || record.dig(:log, :level) || (record["log"] =~ /\W?\berror\b\W?/i ? "ERROR" : (record["log"] =~ /\W?\bwarn\b\W?/i ? "WARN" : (record["log"] =~ /\W?\bdebug\b\W?/i ? "DEBUG" : (record["log"] =~ /\W?\binfo\b\W?/i ? "INFO" : "NONE")))) }
           content ${record["log"]}
           container.name ${record.dig("kubernetes","container_name")}
-          container.image.name ${record.dig("kubernetes","container_image").split(':')[0]}
-          container.image.tag ${record.dig("kubernetes","container_image").split(':')[1]}
+          container.image.name ${record.dig("kubernetes","container_image")&.split(':')&.[](0)}
+          container.image.tag ${record.dig("kubernetes","container_image")&.split(':')&.[](1)}
           dt.kubernetes.node.name ${record.dig("kubernetes","host")}
           dt.kubernetes.cluster.id "#{ENV['CLUSTER_ID']}"
           dt.kubernetes.node.system_uuid ${File.read("/sys/devices/virtual/dmi/id/product_uuid").strip}

--- a/test/integration_fluent/fluent_plugin_test.rb
+++ b/test/integration_fluent/fluent_plugin_test.rb
@@ -41,7 +41,7 @@ class TestFluentPluginIntegration < Test::Unit::TestCase
     puts 'waiting 10s for output plugin to flush'
     sleep 10
 
-    logs = `docker logs fixtures_logsink_1`
+    logs = `docker logs fixtures-logsink-1`
 
     line1 = '[{"foo":"bar"},{"abc":"def"},{"xyz":"123"},{"abc":"def"},{"xyz":"123"}]'
     line2 = '[{"abc":"def"},{"xyz":"123"}]'

--- a/test/integration_fluent/fluent_plugin_test.rb
+++ b/test/integration_fluent/fluent_plugin_test.rb
@@ -19,13 +19,13 @@ require 'net/http'
 
 class TestFluentPluginIntegration < Test::Unit::TestCase
   def setup
-    puts `cd test/integration_fluent/fixtures && docker-compose up -d --force-recreate --build`
+    puts `cd test/integration_fluent/fixtures && docker compose up -d --force-recreate --build`
     puts 'waiting 5s for integration test to start'
     sleep 5
   end
 
   def teardown
-    puts `cd test/integration_fluent/fixtures && docker-compose down`
+    puts `cd test/integration_fluent/fixtures && docker compose down`
   end
 
   def test_fluent_plugin_integration


### PR DESCRIPTION
Use safe navigation operator to get container.image.name and container.image.tag in order to avoid splitting a nil string